### PR TITLE
feat: add Docker configuration for frontend

### DIFF
--- a/curupira/frontend/.dockerignore
+++ b/curupira/frontend/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+yarn-error.log
+.git
+.gitignore
+README.md
+.env
+.nyc_output
+coverage
+.vscode
+.idea
+dist
+build

--- a/curupira/frontend/Dockerfile
+++ b/curupira/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+RUN yarn build
+
+EXPOSE 3000
+
+CMD ["yarn", "preview", "--host", "0.0.0.0", "--port", "3000"]

--- a/curupira/frontend/docker-compose.yml
+++ b/curupira/frontend/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  frontend:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped


### PR DESCRIPTION
## Descrição
- Adiciona Dockerfile para build e produção do frontend
- Adiciona docker-compose.yml para serviço do frontend
- Adiciona .dockerignore para excluir arquivos desnecessários
- Configura imagem Node 20 Alpine
- Expõe porta 3000 para servidor de preview

## Arquivos adicionados
- `curupira/frontend/Dockerfile`
- `curupira/frontend/docker-compose.yml`
- `curupira/frontend/.dockerignore`

## Notas
Esta configuração permite rodar o frontend em container Docker de forma isolada.